### PR TITLE
Bump upper bound for base to <4.9

### DIFF
--- a/total.cabal
+++ b/total.cabal
@@ -20,7 +20,7 @@ Source-Repository head
 Library
     Hs-Source-Dirs: src
     Build-Depends:
-        base     >= 4       && < 4.8,
+        base     >= 4       && < 4.9,
         ghc-prim >= 0.2.0.0 && < 0.4,
         void     >= 0.4     && < 0.8
     Exposed-Modules: Lens.Family.Total


### PR DESCRIPTION
Builds fine for me on ghc 7.10 after bumping upper bound for base to `<4.9` ;)
