### PR TITLE
Fix typo in documentation - example usage

### DIFF
--- a/src/Lens/Family/Total.hs
+++ b/src/Lens/Family/Total.hs
@@ -15,12 +15,12 @@
 -- >     & on _Left  (\c -> replicate 3  c )  --     Left  c -> replicate 3 c
 -- >     & on _Right (\n -> replicate n '!')  --     Right n -> replicate n '!'
 --
--- Our @example@ function pattern matches exhaustively on the `Either` type using
+-- Our @total@ function pattern matches exhaustively on the `Either` type using
 -- the `Lens.Family.Stock._Left` and `Lens.Family.Stock._Right` prisms:
 --
--- >>> example (Left 'X')
+-- >>> total (Left 'X')
 -- "XXX"
--- >>> example (Right 2)
+-- >>> total (Right 2)
 -- "!!"
 --
 -- The types ensure that the above function is total.  For example, if you omit


### PR DESCRIPTION
Looks like the example function was originally called `example` in the usage docs, but got renamed to (the better name) `total`.  A few spots right below it didn't get changed alongside it though.
