### PR TITLE
Generalize on and at

### DIFF
--- a/src/Lens/Family/Complete.hs
+++ b/src/Lens/Family/Complete.hs
@@ -4,6 +4,7 @@
 
 module Lens.Family.Complete
     ( Full(..)
+    , trivialVal
     , GFull(..)
     , _cocase
     , at
@@ -24,6 +25,10 @@ class Full a where
 
     default trivial :: (Generic a, GFull (Rep a)) => x -> a
     trivial = to . gtrivial
+
+-- | A version of 'trivial' without the arrow.
+trivialVal :: Full a => a
+trivialVal = trivial ()
 
 instance Full () where
     trivial = const ()
@@ -56,13 +61,33 @@ instance GFull a => GFull (a :+: b) where
 _cocase :: Full a => x -> a
 _cocase = trivial
 
--- | Copattern match on a `Lens.Family.Traversal`
+-- | Copattern match on a `Lens.Family.Traversal`.
+-- We use a general @'Full' u@ as the target of the traversal
+-- to allow more flexibility for nested products. Given
+--
+-- @
+-- data Rec1 a b = Rec1 { _foo :: a, _bar :: b }
+-- data Rec2 a b c = Rec2 { _baz :: Rec1 a b, _quux :: c }
+-- @
+--
+-- we can build a @Rec2 a b c@ from a @Rec2 () () ()@ using traversals
+-- @baz . foo@ and @baz . bar@ to target @a@ and @b@ (each of which will
+-- start out as @()@), or using @baz@ to target @Rec1 a b@ (which will start
+-- out as @Rec1 () ()@).
 at
-    :: ((() -> Identity b) -> s -> Identity t)
+    :: Full u
+    => ((u -> Identity b) -> s -> Identity t)
     -> (i -> b)
     -> (i -> s)
     -> i
     -> t
-at p f g = convert p . (f &&& g)
-  where
-  convert p' (b, s) = runIdentity $ p' (const $ Identity $ b) s
+at p f g = simpleAt p <$> f <*> g
+
+-- | A version of 'at' that does not build in @Reader@.
+simpleAt
+    :: Full u
+    => ((u -> Identity b) -> s -> Identity t)
+    -> b
+    -> s
+    -> t
+simpleAt p b s = runIdentity $ p (const $ Identity $ b) s

--- a/src/Lens/Family/Total.hs
+++ b/src/Lens/Family/Total.hs
@@ -150,9 +150,22 @@ _case = impossible
 _default :: x -> a -> x
 _default x _ = x
 
--- | Pattern match on a `Lens.Family.Traversal`
+-- | Pattern match on a `Lens.Family.Traversal`.
+-- We use a general @'Empty' v@ to get more flexibility with nested
+-- sums. Given
+--
+-- @
+-- data Sum1 a b = A a | B b
+-- data Sum2 a b c = AB (Sum1 a b) | C c
+-- @
+--
+-- we may want to traverse @Sum2@ with traversals @_AB . _A@
+-- and @_AB . _B@, targeting @a@ and @b@ (each of which can be
+-- 'Void') or use @_AB@ directly to target @Sum1 a b@, which can
+-- be @Sum1 'Void' 'Void'@.
 on
-    :: ((a -> Either a Void) -> s -> Either a r)
+    :: Empty v
+    => ((a -> Either a v) -> s -> Either a r)
     -> (a -> o)
     -> (r -> o)
     -> s


### PR DESCRIPTION
* Generalize `on` and `at` to allow more flexible nesting.
* Add less-categorical, more-Haskellish versions of `at` and
  `trivial`.

Closes #17